### PR TITLE
Remove ldap, upgrade version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,16 +1,16 @@
 {
   "name": "postgresql",
-  "version": "9.6.16",
+  "version": "13.0.0",
   "description": "PostgreSQL packaged for Esy",
   "license": "PostgreSQL Licence",
-  "source": "https://ftp.postgresql.org/pub/source/v9.6.16/postgresql-9.6.16.tar.gz#911d4efc0c428875c1928f98c72e426d22231e59",
+  "source": "https://ftp.postgresql.org/pub/source/v13.0/postgresql-13.0.tar.gz#8862cfd6bbf1d0fe94552d702bc581fa4f866873",
   "override": {
     "buildEnv": {
       "CFLAGS": "-I#{esy-openssl.install / 'include'} $CFLAGS",
       "LDFLAGS": "-L#{esy-openssl.lib} -lcrypto $LDFLAGS"
     },
     "build": [
-      "./configure #{os == 'windows' ? '--host x86_64-w64-mingw32': '' } --prefix=$cur__install --with-openssl --without-readline --disable-debug --enable-thread-safety",
+      "./configure #{os == 'windows' ? '--host x86_64-w64-mingw32': '' } --prefix=$cur__install --with-openssl --without-readline --without-ldap --disable-debug --enable-thread-safety",
       "make"
     ],
     "install": "make install",
@@ -47,7 +47,7 @@
     },
     "dependencies": {
       "esy-zlib": "esy-packages/esy-zlib",
-      "esy-openssl": "esy-packages/esy-openssl"
+      "@reason-native-web/esy-openssl": "^1.1.1000"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
       "LDFLAGS": "-L#{@reason-native-web/esy-openssl.lib} -lcrypto $LDFLAGS"
     },
     "build": [
-      "./configure #{os == 'windows' ? '--host x86_64-w64-mingw32': '' } --prefix=$cur__install --with-openssl --without-readline --without-ldap --disable-debug --enable-thread-safety",
+      "./configure #{os == 'windows' ? '--host x86_64-w64-mingw32': '' } --prefix=$cur__install --with-openssl --without-readline --without-ldap --disable-debug --enable-thread-safety --libdir=#{self.lib}",
       "make"
     ],
     "install": "make install",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
       },
       "LDFLAGS": {
         "scope": "global",
-        "val": "-L#{self.lib} -lpq"
+        "val": "-L#{self.lib} -lpq $LDFLAGS"
       },
       "CPPFLAGS": {
         "scope": "global",

--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "source": "https://ftp.postgresql.org/pub/source/v13.0/postgresql-13.0.tar.gz#8862cfd6bbf1d0fe94552d702bc581fa4f866873",
   "override": {
     "buildEnv": {
-      "CFLAGS": "-I#{esy-openssl.install / 'include'} $CFLAGS",
-      "LDFLAGS": "-L#{esy-openssl.lib} -lcrypto $LDFLAGS"
+      "CFLAGS": "-I#{@reason-native-web/esy-openssl.install / 'include'} $CFLAGS",
+      "LDFLAGS": "-L#{@reason-native-web/esy-openssl.lib} -lcrypto $LDFLAGS"
     },
     "build": [
       "./configure #{os == 'windows' ? '--host x86_64-w64-mingw32': '' } --prefix=$cur__install --with-openssl --without-readline --without-ldap --disable-debug --enable-thread-safety",


### PR DESCRIPTION
I'm not sure if ldap is used in the wild, googling a bit and it seems like it's pretty rare to actually use it.